### PR TITLE
Extend IPersistentMap instead of PersistentArrayMap.

### DIFF
--- a/src/pghstore_clj/core.clj
+++ b/src/pghstore_clj/core.clj
@@ -8,7 +8,7 @@
 (defprotocol FHstorable
   (from-hstore [this]))
 
-(extend-type clojure.lang.PersistentArrayMap
+(extend-type clojure.lang.IPersistentMap
   THstorable
   (to-hstore [this]
     (doto (PGobject.)


### PR DESCRIPTION
Allows PersistentHashMap to be serialized too.
