### PR TITLE
Extended java.util.HashMap with FHstorable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
-(defproject pghstore-clj "0.1.0"
+(defproject pghstore-clj "0.1.2"
   :description "Helper functions for working with PostgresSQL hstore data type in Clojure via JDBC"
   :url "http://github.com/blakesmith/pghstore-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]]
-  :dev-dependencies [[postgresql "9.1-901.jdbc4"]])
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                  [prismatic/plumbing "0.0.1"]]
+  :dev-dependencies [[postgresql "9.2-1002.jdbc4"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject pghstore-clj "0.1.2"
+(defproject net.likestream/pghstore-clj "0.1.2"
   :description "Helper functions for working with PostgresSQL hstore data type in Clojure via JDBC"
   :url "http://github.com/blakesmith/pghstore-clj"
   :license {:name "Eclipse Public License"

--- a/src/pghstore_clj/core.clj
+++ b/src/pghstore_clj/core.clj
@@ -1,5 +1,6 @@
 (ns pghstore-clj.core
-  (:require [clojure.string :as st])
+  (:require [clojure.string :as st]
+            [plumbing.core :refer :all])
   (:import [org.postgresql.util PGobject]))
 
 (defprotocol THstorable
@@ -29,3 +30,12 @@
                          (map #(st/replace % #"\"" "") (st/split v #"=>")))
                        (st/split (.getValue this) #", "))]
               [(keyword k) v])))))
+
+(extend-type java.util.HashMap
+  FHstorable
+  (from-hstore 
+    [this]
+    (->> this
+         (into {})
+         keywordize-map)))
+


### PR DESCRIPTION
Hello @blakesmith (and @citizenparker)

Wow, I was so happy to find this library!
I tried to use it, but ran into issues.  The writes into the DB worked fine,
but the read path back from Postgres -> JDBC -> Korma -> pghstore didn't work.
Somehow, what was getting passed to from-hstore was a java.util.HashMap, not a
org.postgresql.util.PGobject, so no implementation of from-hstore was found for java.util.HashMap.

Has there been a change with one or more "links in the chain" above?

I am running:
Clojure 1.5.1, 
Postgres 9.2.x,  
[org.clojure/java.jdbc "0.2.3"]
[postgresql "9.2-1002.jdbc4"]
[korma "0.3.0-RC5"]

Anyway, I didn't take the time to really dig into this to understand what the issue was.
I simply threw together a very quick and dirty implementation of from-hstore for java.util.HashMap, which is here in my pull request, just FYI.  I'm not claiming my code is the best or right way to do this, if in fact this needs to be done at all...

I'm pretty sure I am unblocked for now, but it would be great to get some more knowledgeable perspective from you guys on this....

Thanks !
